### PR TITLE
Changed int's to float's in pid.cpp

### DIFF
--- a/ardumower/pid.cpp
+++ b/ardumower/pid.cpp
@@ -44,11 +44,11 @@ float PID::compute()
   if (Ta > 1.0) Ta = 1.0;   // should only happen for the very first call
 
   // compute error
-  int16_t e = (w - x);	
+  float e = (w - x);	
   // integrate error
   esum += e;
   // anti wind-up	
-  int iTerm = Ki * Ta * esum;	
+  float iTerm = Ki * Ta * esum;	
   if (iTerm < -max_output)  iTerm = -max_output;
   if (iTerm > max_output)  iTerm = max_output;			
   y = Kp * e
@@ -84,7 +84,7 @@ float VelocityPID::compute()
   if (Ta > 1.0) Ta = 1.0;   // should only happen for the very first call
 
   // compute error
-  int16_t e = (w - x);
+  float e = (w - x);
 
   // compute max/min output
   if (w < 0) { y_min = -max_output; y_max = 0; }


### PR DESCRIPTION
Variables e and iTerm must be float's otherwise there will be calculation errors since the decimal part will be truncated.
