### PR TITLE
Change in software reset for Due

### DIFF
--- a/code/ardumower/drivers.cpp
+++ b/code/ardumower/drivers.cpp
@@ -371,7 +371,7 @@ void softwareReset(){
 #elif __SAM3X8E__
   // Arduino Due  
   RSTC->RSTC_MR = 0xA5000801; // Set RST pin to go low for 256 clock cycles on reset
-  RSTC->RSTC_CR = 0xA5000013; // Reset processor, internal peripherals, and pull external RST pin low.
+  RSTC->RSTC_CR = 0xA500000D; // Reset processor, internal peripherals, and pull external RST pin low.
 #endif
 }
 


### PR DESCRIPTION
According to the datasheet, p.236, the dword to reset proc, periph and extern RST to low is 0xA500000D (bit 0 =1, bit 2 = 1, bit 3 = 1)